### PR TITLE
Change action to use pre published docker image from GitHub Registry 2

### DIFF
--- a/.github/workflows/package-retention-policy.yml
+++ b/.github/workflows/package-retention-policy.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Cleanup old share-jobs-data Docker images
-        uses: snok/container-retention-policy@v1.5.1
+        uses: snok/container-retention-policy@v1
         with:
           image-names: share-jobs-data
           cut-off: One month ago UTC

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -27,18 +27,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/.github/workflows/test-action-current-workflow.yml
+++ b/.github/workflows/test-action-current-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run action with bad input
       id: set-bad-input
-      uses: ./action-local.yml
+      uses: ./action-local
       continue-on-error: true
       with:
         command: set-data
@@ -69,7 +69,7 @@ jobs:
         Write-Output "name=George Washington" >> $env:GITHUB_OUTPUT
     - name: Run set-data command
       id: set
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: set-data
         artifact-name: from-set-with-github-step-json-output
@@ -127,7 +127,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run set-data command
       id: set
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: set-data
         artifact-name: from-set-with-strict-json-output
@@ -211,7 +211,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run set-data command
       id: set
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: set-data
         output: none
@@ -257,7 +257,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run read-data-current-workflow command
       id: read
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: read-data-current-workflow
         artifact-name: from-set-with-github-step-json-output
@@ -300,7 +300,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run read-data-current-workflow command
       id: read
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: read-data-current-workflow
         artifact-name: from-set-with-strict-json-output

--- a/.github/workflows/test-action-different-workflow.yml
+++ b/.github/workflows/test-action-different-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run read-data-different-workflow command
       id: read
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: read-data-different-workflow
         run-id: ${{ github.event.workflow_run.id }}
@@ -79,7 +79,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run read-data-different-workflow command
       id: read
-      uses: ./action-local.yml
+      uses: ./action-local
       with:
         command: read-data-different-workflow
         run-id: ${{ github.event.workflow_run.id }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set data
-      uses: edumserrano/share-jobs-data@v1.0.0
+      uses: edumserrano/share-jobs-data@v1
       with:
         command: set-data
         data: |
@@ -81,7 +81,7 @@ jobs:
     # so that you can use it on subsequent steps
     - name: Read data
       id: read-data  # must have an id so that you can access the output from this step which contains the shared data
-      uses: edumserrano/share-jobs-data@v1.0.0
+      uses: edumserrano/share-jobs-data@v1
       with:
         command: read-data-current-workflow
     - name: Do something with the shared data
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set data
-      uses: edumserrano/share-jobs-data@v1.0.0
+      uses: edumserrano/share-jobs-data@v1
       with:
         command: set-data
         data: |
@@ -140,7 +140,7 @@ jobs:
     # so that you can use it on subsequent steps
     - name: Read data
       id: read-data  # must have an id so that you can access the output from this step which contains the shared data
-      uses: edumserrano/share-jobs-data@v1.0.0
+      uses: edumserrano/share-jobs-data@v1
       with:
         command: read-data-different-workflow
         run-id: ${{ github.event.workflow_run.id }}  # we need to specify the run id of the workflow that shared the data
@@ -296,7 +296,7 @@ jobs:
     steps:
     - name: Set data
       id: set # must have an id so that you can access the output from this step on later steps in the same job
-      uses: edumserrano/share-jobs-data@v1.0.0
+      uses: edumserrano/share-jobs-data@v1
       with:
         command: set-data
         output: github-step-json # or `strict-json`, if you use `none` there won't be any output set on this step
@@ -316,7 +316,7 @@ Yes, you should be able to use most of YAML syntax. To share data with multiple 
 
 ```yml
 - name: Set data
-  uses: edumserrano/share-jobs-data@v1.0.0
+  uses: edumserrano/share-jobs-data@v1
   with:
     command: set-data
     data: |
@@ -346,7 +346,7 @@ Yes, you can build the data to share by hardcoding values or by building it from
   run: |
     Write-Output "name=Eduardo Serrano" >> $env:GITHUB_OUTPUT
 - name: Set data
-  uses: edumserrano/share-jobs-data@v1.0.0
+  uses: edumserrano/share-jobs-data@v1
   with:
     command: set-data
     data: |
@@ -403,7 +403,7 @@ If you're struggling to get the right keys for the output of this action then yo
 #
 - name: Read data
   id: read-data  # must have an id so that you can access the output from this step which contains the shared data
-  uses: edumserrano/share-jobs-data@v1.0.0
+  uses: edumserrano/share-jobs-data@v1
   with:
     command: read-data-current-workflow # this example works with any 'command' value
     output: github-step-json            # this example works with any 'output' value


### PR DESCRIPTION
Continuation of #17:
- Corrected the test workflow reference to `/action-local/action.yml`
- Updated some workflows to use major version instead of full semantic version
- Updated main README to reflect correct usage of this action