### PR TITLE
Still dealing with the fallout from the bad SDK 7.0.200 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,16 @@ RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 # end of install powershell
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+#############
+# temp fix due to sdk 7.0.201 using a preview version of msbuild
+# installing sdk 7.0.103 which doesn't have this problem
+#############
+RUN apk update && apk upgrade && apk add bash
+RUN wget https://dot.net/v1/dotnet-install.sh && chmod +x ./dotnet-install.sh
+ENV DOTNET_INSTALL_FOLDER=/usr/share/dotnet
+RUN ./dotnet-install.sh --version 7.0.103 --install-dir ${DOTNET_INSTALL_FOLDER}
+############# the above block can be deleted when the SDK issue has been resolved
+
 WORKDIR /share-jobs-data
 COPY ["ShareJobsData/NuGet.Config", "ShareJobsData/"]
 COPY ["ShareJobsData/src/ShareJobsDataCli/ShareJobsDataCli.csproj", "ShareJobsData/src/ShareJobsDataCli/"]


### PR DESCRIPTION
The release of `dotnet SDK 7.0.200` broke my build pipeline because a preview version of `MSBuild` started being used.
Previous commits fixed the issue by:
- pinning the SDK version to 7.0.103 until a fix for `MSBuild` is released.
- updating dev README with a note about `global.json`. 
- updating the pipelines to make sure the `global.json` file is respected.
  - the `setup-dotnet` action now uses the `global.json` to determine which version of `dotnet` to install.
  - the `dotnet` CLI commands now run from the directory where `global.json` is. Previously they were run from a directory above and the CLI will only search the current directory and above.

This PR now updates the Dockerfile because a new image has been published that moved the SDK installed from 7.0.103 to 7.0.201. Due to the tag I'm using on the Dockerfile that latest image was picked up and broke the pipeline again.

Related issues:
- dotnet/sdk#30624
- actions/setup-dotnet#383