### PR TITLE
Update to dotnet 8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,6 +35,9 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
       run: $env:GITHUB_CONTEXT
+    - name: Enable git core.longpaths
+      if: matrix.os == 'windows-latest'
+      run:  git config --global core.longpaths true
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Setup .NET

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,11 @@ jobs:
     name: Build and test
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # don't fail if one of the matrix jobs fails. Example: try to run the windows matrix even if the ubuntu matrix fails.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     env:
       SLN_DIR: ShareJobsData
       SLN_FILENAME: ShareJobsData.sln
@@ -93,7 +97,7 @@ jobs:
         }
     - name: Set run even if tests fail condition
       id: even-if-tests-fail
-      if: always()
+      if: matrix.os == 'ubuntu-latest' && always()
       run: |
         # Some of the steps below provide feedback on the test run and I want to run them even if
         # some of the previous steps failed. For that I need:
@@ -109,7 +113,7 @@ jobs:
         Write-Output "condition is set to $condition"
     - name: Generate code coverage report
       id: code-coverage-report-generator
-      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+      if: matrix.os == 'ubuntu-latest' && steps.even-if-tests-fail.outputs.condition == 'true' && always()
       run: |
         $testCoverageReportDir = $(Join-Path -Path ${{ steps.dotnet-test.outputs.test-coverage-dir }} -ChildPath "report")
         Write-Output "test-coverage-report-dir=$testCoverageReportDir" >> $env:GITHUB_OUTPUT
@@ -118,24 +122,26 @@ jobs:
           "-targetdir:$testCoverageReportDir" `
           -reportTypes:htmlInline
     - name: Upload code coverage report to artifacts
-      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+      if: matrix.os == 'ubuntu-latest' && steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}
         path: ${{ steps.code-coverage-report-generator.outputs.test-coverage-report-dir }}
     - name: Upload test results to artifacts
-      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+      if: matrix.os == 'ubuntu-latest' && steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
         path: ${{ steps.dotnet-test.outputs.test-results-dir }}
     - name: Upload test coverage to Codecov
       uses: codecov/codecov-action@v3
+      if: matrix.os == 'ubuntu-latest'
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # even though it's not required for public repos it helps with intermittent failures caused by https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954, https://github.com/codecov/codecov-action/issues/598
         files: ${{ steps.dotnet-test.outputs.test-coverage-file }}
         fail_ci_if_error: true
     - name: Log Codecov info
+      if: matrix.os == 'ubuntu-latest'
       run: |
         $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
         Write-Output "::notice title=Code coverage (${{ runner.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://hub.docker.com/_/microsoft-dotnet-runtime/ for list of tags for dotnet runtime
+# See https://hub.docker.com/_/microsoft-dotnet-sdk for list of tags for dotnet sdk
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
 # install powershell as per https://docs.microsoft.com/en-us/powershell/scripting/install/install-alpine
-ARG PWSH_VERSION=7.3.6
+ARG PWSH_VERSION=7.4.0
 RUN apk add --no-cache \
     ca-certificates \
     less \
@@ -18,14 +20,14 @@ RUN apk add --no-cache \
     icu-libs \
     curl
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
-RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-alpine-x64.tar.gz -o /tmp/powershell.tar.gz
+RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
 RUN mkdir -p /opt/microsoft/powershell/7
 RUN tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
 RUN chmod +x /opt/microsoft/powershell/7/pwsh
 RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 # end of install powershell
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /share-jobs-data
 COPY ["ShareJobsData/NuGet.Config", "ShareJobsData/"]
 COPY ["ShareJobsData/src/ShareJobsDataCli/ShareJobsDataCli.csproj", "ShareJobsData/src/ShareJobsDataCli/"]

--- a/ShareJobsData/.editorconfig
+++ b/ShareJobsData/.editorconfig
@@ -104,32 +104,22 @@ dotnet_diagnostic.CA2007.severity = none        # CA2007: Do not directly await 
 dotnet_diagnostic.CA2234.severity = silent      # CA2234: Pass System.Uri objects instead of strings
 
 ##########################################
-# Language Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# .NET code refactoring options
+# https://learn.microsoft.com/en-us/visualstudio/ide/reference/code-styles-refactoring-options?view=vs-2022
 ##########################################
-# .NET Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.cs]
-# Parentheses preferences
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
-# Expression-level preferences
-dotnet_diagnostic.IDE0010.severity = silent     # Add missing cases to switch statement (IDE0010)
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_diagnostic.IDE0045.severity = suggestion # Use conditional expression for assignment (IDE0045)
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_diagnostic.IDE0046.severity = none       # Use conditional expression for return (IDE0046)
-# Undocumented
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 
-# C# Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+##########################################
+# Language and unnecessary rules
+# https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules
+##########################################
 [*.cs]
-# 'var' preferences
-dotnet_diagnostic.IDE0008.severity = none               # IDE0008: Use explicit type instead of 'var'
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
-# Expression-bodied members
+
+# Code-block preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#code-block-preferences
+dotnet_diagnostic.IDE0290.severity = silent             # Use primary constructor (IDE0290)
+
+# Expression-bodied members https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-bodied-members
 csharp_style_expression_bodied_methods = true:silent
 dotnet_diagnostic.IDE0022.severity = silent             # Use expression body for methods (IDE0022)
 csharp_style_expression_bodied_operators = true:silent
@@ -144,18 +134,27 @@ csharp_style_expression_bodied_lambdas = true:silent
 dotnet_diagnostic.IDE0053.severity = silent             # Use expression body for lambdas (IDE0053)
 csharp_style_expression_bodied_local_functions = true:silent
 dotnet_diagnostic.IDE0061.severity = silent             # Use expression body for local functions (IDE0061)
-# Expression-level preferences
+
+# Expression-level preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-level-preferences
+dotnet_diagnostic.IDE0010.severity = silent     # Add missing cases to switch statement (IDE0010)
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_diagnostic.IDE0045.severity = suggestion # Use conditional expression for assignment (IDE0045)
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_diagnostic.IDE0046.severity = none       # Use conditional expression for return (IDE0046)
 dotnet_diagnostic.IDE0057.severity = none                # Use range operator (IDE0057)
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+dotnet_diagnostic.IDE0058.severity = silent     # Remove unnecessary expression value (IDE0058)
 csharp_style_implicit_object_creation_when_type_is_apparent = false:silent
 dotnet_diagnostic.IDE0090.severity = suggestion          # Simplify new expression (IDE0090)
 
-##########################################
-# Unnecessary Code Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
-##########################################
-[*.cs]
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-dotnet_diagnostic.IDE0058.severity = silent     # Remove unnecessary expression value (IDE0058)
+# Parentheses preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#parentheses-preferences
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# 'var' preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#var-preferences
+dotnet_diagnostic.IDE0008.severity = none               # IDE0008: Use explicit type instead of 'var'
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
 ##########################################
 # Formatting Rules
@@ -498,7 +497,7 @@ dotnet_diagnostic.SA1006.severity = suggestion  # SA1006: Preprocessor keywords 
 dotnet_diagnostic.SA1007.severity = suggestion  # SA1007: Operator keyword should be followed by space
 dotnet_diagnostic.SA1008.severity = suggestion  # SA1008: Opening parenthesis should be spaced correctly
 dotnet_diagnostic.SA1009.severity = suggestion  # SA1009: Closing parenthesis should be spaced correctly
-dotnet_diagnostic.SA1010.severity = suggestion  # SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = none        # SA1010: Opening square brackets should be spaced correctly # TODO review this, temporarily disabled until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687 is resolved. Hopefully soon by merging https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3729
 dotnet_diagnostic.SA1011.severity = suggestion  # SA1011: Closing square brackets should be spaced correctly
 dotnet_diagnostic.SA1012.severity = suggestion  # SA1012: Opening braces should be spaced correctly
 dotnet_diagnostic.SA1013.severity = suggestion  # SA1013: Closing braces should be spaced correctly

--- a/ShareJobsData/global.json
+++ b/ShareJobsData/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "7.0.x",
+        "version": "8.0.x",
         "rollForward": "disable",
         "allowPrerelease": false
     }

--- a/ShareJobsData/src/ShareJobsDataCli/Common/Cli/Errors/CommandExceptionThrowHelper.cs
+++ b/ShareJobsData/src/ShareJobsDataCli/Common/Cli/Errors/CommandExceptionThrowHelper.cs
@@ -16,5 +16,5 @@ internal static class CommandExceptionThrowHelper
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Exception CreateCommandException(string errorMessage) => new CommandException(errorMessage);
+    private static CommandException CreateCommandException(string errorMessage) => new CommandException(errorMessage);
 }

--- a/ShareJobsData/src/ShareJobsDataCli/Features/ReadDataCurrentWorkflow/ReadDataFromCurrentGitHubWorkflowCommand.cs
+++ b/ShareJobsData/src/ShareJobsDataCli/Features/ReadDataCurrentWorkflow/ReadDataFromCurrentGitHubWorkflowCommand.cs
@@ -25,21 +25,21 @@ public sealed class ReadDataFromCurrentGitHubWorkflowCommand : ICommand
     [CommandOption(
         "artifact-name",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The name of the artifact.")]
     public string ArtifactName { get; init; } = CommandOptionsDefaults.ArtifactName;
 
     [CommandOption(
         "data-filename",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The filename that contains the data.")]
     public string ArtifactFilename { get; init; } = CommandOptionsDefaults.ArtifactFilename;
 
     [CommandOption(
         "output",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "How to output the job data in the step's output. It must be one of: strict-json, github-step-json.")]
     public string Output { get; init; } = "github-step-json";
 

--- a/ShareJobsData/src/ShareJobsDataCli/Features/ReadDataDifferentWorkflow/ReadDataFromDifferentGitHubWorkflowCommand.cs
+++ b/ShareJobsData/src/ShareJobsDataCli/Features/ReadDataDifferentWorkflow/ReadDataFromDifferentGitHubWorkflowCommand.cs
@@ -25,42 +25,42 @@ public sealed class ReadDataFromDifferentGitHubWorkflowCommand : ICommand
     [CommandOption(
         "auth-token",
         IsRequired = true,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "GitHub token used to download the job data artifact.")]
     public string AuthToken { get; init; } = default!;
 
     [CommandOption(
         "repo",
         IsRequired = true,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The repository for the workflow run in the format of {owner}/{repo}.")]
     public string Repo { get; init; } = default!;
 
     [CommandOption(
         "run-id",
         IsRequired = true,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The unique identifier of the workflow run that contains the job data artifact.")]
     public string RunId { get; init; } = default!;
 
     [CommandOption(
         "artifact-name",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The data to share in YAML format.")]
     public string ArtifactName { get; init; } = CommandOptionsDefaults.ArtifactName;
 
     [CommandOption(
         "data-filename",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The data to share in YAML format.")]
     public string ArtifactFilename { get; init; } = CommandOptionsDefaults.ArtifactFilename;
 
     [CommandOption(
         "output",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "How to output the job data in the step's output. It must be one of: strict-json, github-step-json.")]
     public string Output { get; init; } = "github-step-json";
 

--- a/ShareJobsData/src/ShareJobsDataCli/Features/SetData/SetDataCommand.cs
+++ b/ShareJobsData/src/ShareJobsDataCli/Features/SetData/SetDataCommand.cs
@@ -25,28 +25,28 @@ public sealed class SetDataCommand : ICommand
     [CommandOption(
         "artifact-name",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The name of the artifact.")]
     public string ArtifactName { get; init; } = CommandOptionsDefaults.ArtifactName;
 
     [CommandOption(
         "data-filename",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The filename that contains the data.")]
     public string ArtifactFilename { get; init; } = CommandOptionsDefaults.ArtifactFilename;
 
     [CommandOption(
         "data",
         IsRequired = true,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The data to share in YAML format.")]
     public string DataAsYmlStr { get; init; } = default!;
 
     [CommandOption(
         "output",
         IsRequired = false,
-        Validators = new[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "How to output the job data in the step's output. It must be one of: none, strict-json, github-step-json.")]
     public string Output { get; init; } = "none";
 

--- a/ShareJobsData/src/ShareJobsDataCli/ShareJobsDataCli.csproj
+++ b/ShareJobsData/src/ShareJobsDataCli/ShareJobsDataCli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ShareJobsData/tests/ShareJobsDataCli.Tests/Auxiliary/Http/GitHubHttpClient/BaseResponseMockBuilder.cs
+++ b/ShareJobsData/tests/ShareJobsDataCli.Tests/Auxiliary/Http/GitHubHttpClient/BaseResponseMockBuilder.cs
@@ -1,7 +1,7 @@
 namespace ShareJobsDataCli.Tests.Auxiliary.Http.GitHubHttpClient;
 
 // The signature `BaseResponseMockBuilder<T> where T : BaseResponseMockBuilder<T>`
-// looks weird at first sight right? 
+// looks weird at first sight right?
 //
 // Here are a few links that help explain the benefits of implementing `A<T> : A<T>` and using the
 // `return (T)this;` in the base class:

--- a/ShareJobsData/tests/ShareJobsDataCli.Tests/Auxiliary/Verify/RemoteTestEnvironment.cs
+++ b/ShareJobsData/tests/ShareJobsDataCli.Tests/Auxiliary/Verify/RemoteTestEnvironment.cs
@@ -16,12 +16,7 @@ internal sealed class RemoteTestEnvironment
     private static readonly Lazy<RemoteTestEnvironment> _instance = new Lazy<RemoteTestEnvironment>(() => new RemoteTestEnvironment());
     private readonly string _solutionDirectory = string.Empty;
     private readonly string _remoteTestEnvironmentSolutionDir = string.Empty;
-
-    private readonly char[] _separators =
-    {
-        '\\',
-        '/',
-    };
+    private readonly char[] _separators = ['\\', '/'];
 
     private RemoteTestEnvironment()
     {

--- a/ShareJobsData/tests/ShareJobsDataCli.Tests/ShareJobsDataCli.Tests.csproj
+++ b/ShareJobsData/tests/ShareJobsDataCli.Tests/ShareJobsDataCli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject> <!-- This shouldn't be needed because it should be added by the Microsoft.NET.Test.Sdk package but for now it's required as explained here https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198 -->
   </PropertyGroup>

--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -18,6 +18,11 @@
 
 ## Building the ShareJobsData solution
 
+> **Warning**
+>
+> Before cloning the repo make sure you have `core.longpaths` set to `true` on git by running `git config --global core.longpaths true`
+>
+
 ### Building with Visual Studio
 
 1) Clone the repo and open the **ShareJobsData.sln** solution file at `/ShareJobsData`.


### PR DESCRIPTION
- Update to use dotnet 8
- Fix some warnings
- Update pipeline to also build and run tests on windows. This makes sure tests won't pass on the pipeline but then fail when running on Windows machines.
- Add dev note about `core.longpaths` being required.